### PR TITLE
[BE] Fix: 멤버 테이블 카카오로그인 구분 컬럼 추가 및 아이디 컬럼명 변경

### DIFF
--- a/src/main/java/com/playdata/eungae/member/domain/Member.java
+++ b/src/main/java/com/playdata/eungae/member/domain/Member.java
@@ -55,6 +55,6 @@ public class Member extends BaseEntity {
 	private Integer yCoordinate;
 	
 	//0이면 일반 로그인 1이면 카카오 로그인
-	@Column(columnDefinition = "varchar(1) default ‘0’")
+	@Column(columnDefinition = "varchar(1) default '0'")
 	private String kakaoCheck;
 }

--- a/src/main/java/com/playdata/eungae/member/domain/Member.java
+++ b/src/main/java/com/playdata/eungae/member/domain/Member.java
@@ -55,6 +55,6 @@ public class Member extends BaseEntity {
 	private Integer yCoordinate;
 	
 	//0이면 일반 로그인 1이면 카카오 로그인
-	@ColumnDefault("'0'") 
+	@Column(columnDefinition = "varchar(1) default ‘0’")
 	private String kakaoCheck;
 }

--- a/src/main/java/com/playdata/eungae/member/domain/Member.java
+++ b/src/main/java/com/playdata/eungae/member/domain/Member.java
@@ -1,6 +1,6 @@
 package com.playdata.eungae.member.domain;
 
-import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 import com.playdata.eungae.base.BaseEntity;
 
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@DynamicInsert
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -56,5 +57,6 @@ public class Member extends BaseEntity {
 	
 	//0이면 일반 로그인 1이면 카카오 로그인
 	@Column(columnDefinition = "varchar(1) default '0'")
-	private String kakaoCheck;
+	private boolean kakaoCheck;
+
 }

--- a/src/main/java/com/playdata/eungae/member/domain/Member.java
+++ b/src/main/java/com/playdata/eungae/member/domain/Member.java
@@ -1,5 +1,7 @@
 package com.playdata.eungae.member.domain;
 
+import org.hibernate.annotations.ColumnDefault;
+
 import com.playdata.eungae.base.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -25,7 +27,7 @@ public class Member extends BaseEntity {
 	private Long memberSeq;
 
 	@Column(nullable = false, unique = true)
-	private String memberId;
+	private String email;
 
 	@Column(nullable = false, length = 30)
 	private String password;
@@ -51,4 +53,8 @@ public class Member extends BaseEntity {
 	private Integer xCoordinate;
 
 	private Integer yCoordinate;
+	
+	//0이면 일반 로그인 1이면 카카오 로그인
+	@ColumnDefault("'0'") 
+	private String kakaoCheck;
 }


### PR DESCRIPTION
Fix: 멤버 테이블 카카오로그인 구분 컬럼 추가 및 아이디 컬럼명 변경했습니다.
This closes #147